### PR TITLE
fix: use tsx only from typescript-base-isolated, closes #67

### DIFF
--- a/infra/build/typescript-base-isolated/tsx/cjs.js
+++ b/infra/build/typescript-base-isolated/tsx/cjs.js
@@ -1,0 +1,1 @@
+require('tsx/cjs');

--- a/infra/code-checks/code-problem-snapshotter/package.json
+++ b/infra/code-checks/code-problem-snapshotter/package.json
@@ -48,7 +48,6 @@
     "chalk": "^5.4.1",
     "json-stable-stringify": "^1.1.1",
     "prettier": "^3.4.2",
-    "tsx": "^4.19.1",
     "typescript": "^5.3.3"
   },
   "devtoolsDependencies": [

--- a/infra/code-checks/code-problem-snapshotter/release-it.npm.ts
+++ b/infra/code-checks/code-problem-snapshotter/release-it.npm.ts
@@ -1,6 +1,6 @@
 /** This file is imported & transpiled by `release-it` */
 // eslint-disable-next-line simple-import-sort/imports -- We need tsx import first
-import 'tsx/cjs';
+import '@repo/typescript-base-isolated/tsx/cjs.js';
 
 import baseConfig, {
   ReleaseItConfig,

--- a/infra/code-checks/eslint-problem-snapshotter/package.json
+++ b/infra/code-checks/eslint-problem-snapshotter/package.json
@@ -47,7 +47,6 @@
     "@repo/release-it-base-isolated": "workspace:^",
     "@repo/typescript-base-isolated": "workspace:^",
     "prettier": "^3.4.2",
-    "tsx": "^4.19.1",
     "typescript": "^5.3.3"
   },
   "devtoolsDependencies": [

--- a/infra/code-checks/eslint-problem-snapshotter/release-it.npm.ts
+++ b/infra/code-checks/eslint-problem-snapshotter/release-it.npm.ts
@@ -1,6 +1,6 @@
 /** This file is imported & transpiled by `release-it` */
 // eslint-disable-next-line simple-import-sort/imports -- We need tsx import first
-import 'tsx/cjs';
+import '@repo/typescript-base-isolated/tsx/cjs.js';
 
 import baseConfig, {
   ReleaseItConfig,

--- a/infra/code-checks/lit-analyzer-wrapper/package.json
+++ b/infra/code-checks/lit-analyzer-wrapper/package.json
@@ -45,8 +45,7 @@
     "@repo/release-it-base-isolated": "workspace:^",
     "@repo/typescript-base-isolated": "workspace:^",
     "@types/markdown-it": "^14.1.2",
-    "prettier": "^3.4.2",
-    "tsx": "^4.19.1"
+    "prettier": "^3.4.2"
   },
   "devtoolsDependencies": [
     "@repo/depcheck-base-isolated",

--- a/infra/code-checks/lit-analyzer-wrapper/release-it.npm.ts
+++ b/infra/code-checks/lit-analyzer-wrapper/release-it.npm.ts
@@ -1,6 +1,6 @@
 /** This file is imported & transpiled by `release-it` */
 // eslint-disable-next-line simple-import-sort/imports -- We need tsx import first
-import 'tsx/cjs';
+import '@repo/typescript-base-isolated/tsx/cjs.js';
 
 import baseConfig from '@repo/release-it-base-isolated/base';
 

--- a/infra/code-checks/tsc-problem-snapshotter/package.json
+++ b/infra/code-checks/tsc-problem-snapshotter/package.json
@@ -48,7 +48,6 @@
     "@repo/release-it-base-isolated": "workspace:^",
     "@repo/typescript-base-isolated": "workspace:^",
     "prettier": "^3.4.2",
-    "tsx": "^4.19.1",
     "typescript": "^5.3.3"
   },
   "devtoolsDependencies": [

--- a/infra/code-checks/tsc-problem-snapshotter/release-it.npm.ts
+++ b/infra/code-checks/tsc-problem-snapshotter/release-it.npm.ts
@@ -1,6 +1,6 @@
 /** This file is imported & transpiled by `release-it` */
 // eslint-disable-next-line simple-import-sort/imports -- We need tsx import first
-import 'tsx/cjs';
+import '@repo/typescript-base-isolated/tsx/cjs.js';
 
 import baseConfig, {
   ReleaseItConfig,

--- a/infra/devx-and-repo/generators/_templates/add/release/base-files/release-it.npm.ts
+++ b/infra/devx-and-repo/generators/_templates/add/release/base-files/release-it.npm.ts
@@ -2,7 +2,7 @@
  * This file is imported & transpiled by `release-it`
  */
 // eslint-disable-next-line simple-import-sort/imports -- We need tsx import first
-import 'tsx/cjs';
+import '@repo/typescript-base-isolated/tsx/cjs.js';
 
 import baseConfig, { ReleaseItConfig } from '@repo/release-it-base-isolated/base';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,9 +328,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tsx:
-        specifier: ^4.19.1
-        version: 4.19.1
       typescript:
         specifier: ^5.3.3
         version: 5.6.2
@@ -455,9 +452,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tsx:
-        specifier: ^4.19.1
-        version: 4.19.1
       typescript:
         specifier: ^5.3.3
         version: 5.6.2
@@ -544,9 +538,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tsx:
-        specifier: ^4.19.1
-        version: 4.19.1
 
   infra/code-checks/syncpack-base-isolated:
     dependencies:
@@ -603,9 +594,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tsx:
-        specifier: ^4.19.1
-        version: 4.19.1
       typescript:
         specifier: ^5.3.3
         version: 5.6.2


### PR DESCRIPTION
## Describe your changes

## Checklist

- [x] You did not commit with `--no-verify`
- [x] You have completed the onboarding script:
      `pnpm --workspace-root run generate repo onboard`
- [x] If PR checks are failing you ran
      `pnpm --filter='<your package name>' run lint:everything` locally
